### PR TITLE
MVC1_修正版レビュー

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
@@ -55,7 +55,7 @@ public class WebSecurityConfig {
 				.formLogin(
 						login -> login.loginPage(UrlConsts.LOGIN)
 								.usernameParameter(ADMIN_ID)
-								.defaultSuccessUrl(UrlConsts.STOCK_LIST))
+								.defaultSuccessUrl(UrlConsts.CATEGORY_INFO))
 				.logout(logout -> logout.logoutSuccessUrl(UrlConsts.LOGIN));
 
 		return http.build();

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
@@ -55,7 +55,7 @@ public class WebSecurityConfig {
 				.formLogin(
 						login -> login.loginPage(UrlConsts.LOGIN)
 								.usernameParameter(ADMIN_ID)
-								.defaultSuccessUrl(UrlConsts.CATEGORY_INFO))
+								.defaultSuccessUrl(UrlConsts.STOCK_LIST))
 				.logout(logout -> logout.logoutSuccessUrl(UrlConsts.LOGIN));
 
 		return http.build();

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -26,6 +26,9 @@ public class UrlConsts {
 	// 在庫センター情報画面 検索
 	public static final String CENTER_INFO_SEARCH = "/admin/centerInfo/search";
 	
+	// 分類情報画面
+	public static final String CATEGORY_INFO = "/admin/categoryInfo";	
+	
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
@@ -1,0 +1,51 @@
+package com.digitalojt.web.controller;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.service.CategoryInfoService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報管理画面のコントローラークラス
+ * 
+ * @author ueno
+ *
+ */
+ 
+
+@Controller
+@RequiredArgsConstructor
+public class CategoryInfoController {
+	
+	/** 分類情報 サービス */
+	private final CategoryInfoService categoryInfoService;
+
+	/** メッセージソース */
+	private final MessageSource messageSource;
+		
+	/**
+	 * 初期表示
+	 * 
+	 * @param model
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CATEGORY_INFO)
+	public String index(Model model) {
+
+		// HelloWorldに表示するデータを取得
+		String helloWorld = categoryInfoService.getHelloWorld();
+
+		// HelloWorldに商品情報リストをセット
+		model.addAttribute("helloWorld", helloWorld);
+
+
+		return "admin/categoryInfo/index";
+	}
+
+}
+

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
@@ -1,0 +1,33 @@
+package com.digitalojt.web.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 分類情報Entity
+ * 
+ * @author ueno
+ *
+ */
+@Data
+@Getter
+@Setter
+@Entity
+public class CategoryInfo {
+
+	@Id
+	private int category_id;
+	
+	/*
+	varchar category_name;
+	
+	varchar delete_flag;
+	
+	datetime create_data;
+	
+	date time update_data;
+	*/
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -1,0 +1,26 @@
+package com.digitalojt.web.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報画面のサービスクラス
+ *
+ * @author ueno
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryInfoService {
+
+	/**
+	 * HelloWorldの画面出力用データの作成
+	 * @return
+	 */
+	public String getHelloWorld() {
+		return "HelloWorld";
+	}
+	
+	
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
+>
+  <head>
+    <title>InvenTrack</title>
+  </head>
+
+  <body>
+	<div th:text="${helloWorld}"> </div>
+  </body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categoryInfo'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">


### PR DESCRIPTION
概要
MVC1
分類情報画面の実装
・HelloWorldの表示
・サイドメニューから遷移可能にする

実装方針・詳細
-分類情報画面の実装。
・HelloWorldを分類情報画面で表示する。
・上記画面のコントローラ作成
　コントローラは変数に”Hello World”を格納するようモデルへ指示する。
　ビュー（html）へ変数の内容を表示するよう指示する
・上記画面のモデル作成
　モデルはコントローラから指示を受けると”Hello World”を返す
-サイドメニューから遷移可能にする。

実装方針・詳細 1
・ 分類情報画面の実装
・HelloWorldの表示
・上記に伴う分類情報画面Control・Modelの実装
実装方針・詳細 2
・サイドメニューからの分類情報画面遷移
実装方針・詳細 3
・ログイン時、初期表示画面を分類情報画面にした

影響範囲
・サイドメニュー
　分類情報をクリックした際に、分類情報画面へ遷移するように変更
・分類情報画面(html)
　画面の追加。画面に「Hello World」と表示する
・分類情報画面のコントロール追加(java)
　コントローラは変数に”Hello World”を格納するようモデルへ指示する。
・分類情報画面のモデル追加(java)
　モデルはコントローラから指示を受けると”Hello World”を返す
・定数
　分類情報画面用の定数「CATEGORY_INFO」を定義する