### PR TITLE
センター情報画面　削除画面実装

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -57,7 +57,7 @@ public class ErrorMessage {
 	public static final String FROM_TO_INPUT_ERROR_MESSAGE = "from.to.input";
 
 	// 在庫が存在する在庫センターを削除しようとしたときに関するエラーメッセージ
-	public static final String CANNOT_DELETE_CENTER_ERROR_MESSAGE = "cannot.delete.center";
+	public static final String CENTERINFO_DELETE_LINKING_ERROR_MESSAGE = "centerInfoDelete.linking";
 
 	// 在庫センター登録・更新画面で必須項目が全て入力されていないときに関するエラーメッセージ
 	public static final String DATA_FILED_EMPTY_ERROR_MESSAGE = "centerInfo.date.fieldEmpty";
@@ -69,7 +69,7 @@ public class ErrorMessage {
 	public static final String CURRENT_STORAGE_ERROR_MESSAGE = "centerInfo.date.currentStorageCapacity.wrongInput";
 
 	// 在庫センター登録・更新画面で現在容量が最大容量を上回る数値が入力されたときに関するエラーメッセージ
-	public static final String OVER_STORAGE_ERROR_MESSAGE = "centerInfo.date.overStorageCapacity.wrongInput";
+	public static final String OVER_STORAGE_ERROR_MESSAGE = "centerInfo.data.StorageCapacityOver";
 
 	// 在庫センター登録画面でデータ登録時にトランザクションエラーが起きたときに関するエラーメッセージ
 	public static final String TRANSACTION_ERROR_MESSAGE = "centerInfoRegister.transactionError";

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/NumberValidConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/NumberValidConsts.java
@@ -37,4 +37,11 @@ public class NumberValidConsts {
 
 	//稼働停止状態の値
 	public static final String INVALID_NUMBER = "1";
+
+	//論理削除フラグの未削除状態の値
+	public static final String DELETE_FLAG_REGISTER_NUMBER = "0";
+
+	//論理削除フラグの削除状態の値
+	public static final String DELETE_FLAG_DELETE_NUMBER = "1";
+	
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/SystemMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/SystemMessage.java
@@ -14,4 +14,7 @@ public class SystemMessage {
 	// センター情報更新画面でデータの登録に成功した時のメッセージ
 	public static final String CENTERINFO_UPDATE_SUCCESS = "centerInfoUpdate.success";
 
+	// センター情報更新画面でデータの登録に成功した時のメッセージ
+	public static final String CENTERINFO_DELETE_SUCCESS = "centerInfoDelete.success";
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
@@ -307,7 +307,7 @@ public class CenterInfoController extends AbstractController {
 	 * @return
 	 */
 	@PatchMapping(UrlConsts.CENTER_INFO_DELETE)
-	public String postDelete(Model model, @Valid CenterInfoForm form, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+	public String postDelete(@ModelAttribute("centerId") Integer centerId, Model model, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
 
 		try {
 			// Valid項目チェック
@@ -316,12 +316,12 @@ public class CenterInfoController extends AbstractController {
 				// エラーメッセージをプロパティファイルから取得
 				redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, bindingResult.getGlobalError().getDefaultMessage()));
 
-				return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+				return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+centerId;
 
 			}
 
 			// データの更新(論理削除)処理を実行する
-			centerInfoService.deleteCenterInfoData(form);
+			centerInfoService.deleteCenterInfoData(centerId);
 
 			// 削除成功時のメッセージを設定する
 			redirectAttributes.addFlashAttribute("systemMsg", MessageManager.getMessage(messageSource, SystemMessage.CENTERINFO_DELETE_SUCCESS));
@@ -332,17 +332,17 @@ public class CenterInfoController extends AbstractController {
 		}catch(Error error) {
 			//在庫一覧でセンター名が使用されている際のエラー処理
 			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.CENTERINFO_DELETE_LINKING_ERROR_MESSAGE));
-			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+centerId;
 		}
 		catch (NullPointerException NullError) {
 			//Nullエラー処理
 			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.LIST_EMPTY_ERROR_MESSAGE));
-			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+centerId;
 		} 
 		catch (Exception error) {
 			//全ての例外処理
 			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.UNEXPECT_ERROR_MESSAGE));
-			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+centerId;
 		} 
 
 	}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
@@ -254,7 +254,12 @@ public class CenterInfoController extends AbstractController {
 			// 更新完了時に在庫センター情報画面にリダイレクト
 			return "redirect:" + UrlConsts.CENTER_INFO;
 
-		} catch (NullPointerException categoryNullError) {
+		} catch (Error linkingError) {
+			//エラー処理
+			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.CENTERINFO_DELETE_LINKING_ERROR_MESSAGE));
+			return "redirect:" + UrlConsts.CENTER_INFO_UPDATE+"/"+form.getCenterId();
+		
+		} catch (NullPointerException NullError) {
 			//Nullエラー処理
 			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.LIST_EMPTY_ERROR_MESSAGE));
 			return "redirect:" + UrlConsts.CENTER_INFO_UPDATE+"/"+form.getCenterId();
@@ -263,6 +268,81 @@ public class CenterInfoController extends AbstractController {
 			//全ての例外処理
 			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.UNEXPECT_ERROR_MESSAGE));
 			return "redirect:" + UrlConsts.CENTER_INFO_UPDATE+"/"+form.getCenterId();
+		} 
+
+	}
+	
+
+	/**
+	 *削除画面表示
+	 * 
+	 * @param model
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CENTER_INFO_DELETE+"/{centerId}")
+	public String getDelete(Model model, @PathVariable("centerId") Integer centerId) {
+
+		try {
+			// 在庫センター情報画面に表示するデータを取得
+			CenterInfo centerInfoList = centerInfoService.getCenterInfoData(centerId);
+
+			// 画面表示用に商品情報リストをセット
+			model.addAttribute("centerInfoList", centerInfoList);
+
+			return UrlConsts.CENTER_INFO_DELETE;
+
+		} catch (Exception error) {
+			//全ての例外処理
+			String errorMsg = MessageManager.getMessage(messageSource, ErrorMessage.UNEXPECT_ERROR_MESSAGE);
+			model.addAttribute("errorMsg", errorMsg);
+			return UrlConsts.CENTER_INFO_DELETE;
+		}
+	}
+
+	/**
+	 * 削除処理
+	 * 
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PatchMapping(UrlConsts.CENTER_INFO_DELETE)
+	public String postDelete(Model model, @Valid CenterInfoForm form, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+
+		try {
+			// Valid項目チェック
+			if (bindingResult.hasErrors()) {
+
+				// エラーメッセージをプロパティファイルから取得
+				redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, bindingResult.getGlobalError().getDefaultMessage()));
+
+				return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+
+			}
+
+			// データの更新(論理削除)処理を実行する
+			centerInfoService.deleteCenterInfoData(form);
+
+			// 削除成功時のメッセージを設定する
+			redirectAttributes.addFlashAttribute("systemMsg", MessageManager.getMessage(messageSource, SystemMessage.CENTERINFO_DELETE_SUCCESS));
+
+			// 削除完了時に在庫センター情報画面にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+
+		}catch(Error error) {
+			//在庫一覧でセンター名が使用されている際のエラー処理
+			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.CENTERINFO_DELETE_LINKING_ERROR_MESSAGE));
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+		}
+		catch (NullPointerException NullError) {
+			//Nullエラー処理
+			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.LIST_EMPTY_ERROR_MESSAGE));
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
+		} 
+		catch (Exception error) {
+			//全ての例外処理
+			redirectAttributes.addFlashAttribute("errorMsg", MessageManager.getMessage(messageSource, ErrorMessage.UNEXPECT_ERROR_MESSAGE));
+			return "redirect:" + UrlConsts.CENTER_INFO_DELETE+"/"+form.getCenterId();
 		} 
 
 	}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
@@ -2,7 +2,6 @@ package com.digitalojt.web.form;
 
 import java.sql.Timestamp;
 
-import com.digitalojt.web.consts.NumberValidConsts;
 import com.digitalojt.web.validation.CenterInfoFormValidator;
 
 import jakarta.persistence.Id;
@@ -88,27 +87,5 @@ public class CenterInfoForm {
 	 * 更新日時
 	 */
 	private Timestamp updateDate;
-
-	/**
-	 * 論理削除フラグを未削除（0）に設定
-	 * 
-	 * @return
-	 */
-	public String getDeleteFlagRegister() {
-
-		deleteFlag = NumberValidConsts.DELETE_FLAG_REGISTER_NUMBER;
-		return deleteFlag;
-	}
-
-	/**
-	 * 論理削除フラグを削除（1）に設定
-	 * 
-	 * @return
-	 */
-	public String getDeleteFlagDeleter() {
-
-		deleteFlag = NumberValidConsts.DELETE_FLAG_DELETE_NUMBER;
-		return deleteFlag;
-	}
 
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
@@ -2,6 +2,7 @@ package com.digitalojt.web.form;
 
 import java.sql.Timestamp;
 
+import com.digitalojt.web.consts.NumberValidConsts;
 import com.digitalojt.web.validation.CenterInfoFormValidator;
 
 import jakarta.persistence.Id;
@@ -79,45 +80,14 @@ public class CenterInfoForm {
 	private String deleteFlag;
 
 	/**
-	 * 論理削除フラグ登録時の初期値
-	 */
-	private String deleteFlagRegisterNumber = "0";
-
-	/**
-	 * 容量(From)
-	 */
-	private Integer storageCapacityFrom;
-
-	/**
-	 * 容量(To)
-	 */
-	private Integer storageCapacityTo;
-
-	// 容量(From)初期値
-	final int INITIAL_CAPACITY_FROM = 10;
-
-	/**
 	 * 作成日時
 	 */
 	private Timestamp createDate;
-	
+
 	/**
 	 * 更新日時
 	 */
 	private Timestamp updateDate;
-
-	/**
-	 * 容量(From)のデフォルト値（10）を設定
-	 * 
-	 * @return
-	 */
-	public Integer getStorageCapacityFrom() {
-
-		if (storageCapacityTo != null && storageCapacityFrom == null) {
-			return INITIAL_CAPACITY_FROM;
-		}
-		return storageCapacityFrom;
-	}
 
 	/**
 	 * 論理削除フラグを未削除（0）に設定
@@ -126,7 +96,18 @@ public class CenterInfoForm {
 	 */
 	public String getDeleteFlagRegister() {
 
-		deleteFlag = deleteFlagRegisterNumber;
+		deleteFlag = NumberValidConsts.DELETE_FLAG_REGISTER_NUMBER;
+		return deleteFlag;
+	}
+
+	/**
+	 * 論理削除フラグを削除（1）に設定
+	 * 
+	 * @return
+	 */
+	public String getDeleteFlagDeleter() {
+
+		deleteFlag = NumberValidConsts.DELETE_FLAG_DELETE_NUMBER;
 		return deleteFlag;
 	}
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
@@ -42,4 +42,14 @@ public interface CenterInfoRepository extends JpaRepository<CenterInfo, Integer>
 			"(:centerId = s.centerId)")
 	CenterInfo findByCenterId(Integer centerId);
 
+	/**
+	 * 引数に合致する在庫センター情報を在庫一覧からカウントする
+	 * 
+	 * @param centerId
+	 * @return paramで検索した結果
+	 */
+	@Query("SELECT COUNT(*) FROM StockInfo s WHERE " +
+			"(s.centerInfo.centerId=:centerId)")
+	int count(int centerId);
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
@@ -120,9 +120,11 @@ public class CenterInfoService {
 
 		// インスタンス化
 		CenterInfo entity = new CenterInfo();
+		
+		//データベースの在庫センター情報を取得
+		entity = repository.findByCenterId(form.getCenterId());
 
 		//各データを格納する
-		entity.setCenterId(form.getCenterId());
 		entity.setCenterName(form.getCenterName());
 		entity.setPostCode(form.getPostCode());
 		entity.setAddress(form.getAddress());
@@ -137,6 +139,37 @@ public class CenterInfoService {
 		entity.setUpdateDate(currentTimestamp);
 
 		//データの更新を実行
+		repository.save(entity);
+	}
+
+	/**
+	 * 在庫センター情報を削除
+	 * 
+	 * @param deleteFlag
+	 * @param updateDate
+	 * @return
+	 */
+	@Transactional
+	public void deleteCenterInfoData(CenterInfoForm form) {
+
+		// インスタンス化
+		CenterInfo entity = new CenterInfo();
+
+		//データベースの在庫センター情報を取得
+		entity = repository.findByCenterId(form.getCenterId());
+		
+		//在庫一覧とリンクしているセンター名があるか確認
+		if(repository.count(form.getCenterId()) > 0) {
+			//在庫一覧とリンクしているセンター名がある場合、エラーを発生させて処理を中断する
+			throw new Error();
+		}
+
+		//各データを格納する
+		entity.setDeleteFlag(form.getDeleteFlagDeleter());
+		Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
+		entity.setUpdateDate(currentTimestamp);
+
+		//データの更新(論理削除)を実行
 		repository.save(entity);
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.digitalojt.web.consts.NumberValidConsts;
 import com.digitalojt.web.entity.CenterInfo;
 import com.digitalojt.web.form.CenterInfoForm;
 import com.digitalojt.web.repository.CenterInfoRepository;
@@ -78,7 +79,7 @@ public class CenterInfoService {
 		entity.setOperationalStatus(form.getOperationalStatus());
 		entity.setMaxStorageCapacity(form.getMaxStorageCapacity());
 		entity.setCurrentStorageCapacity(form.getCurrentStorageCapacity());
-		entity.setDeleteFlag(form.getDeleteFlagRegister());
+		entity.setDeleteFlag(NumberValidConsts.DELETE_FLAG_REGISTER_NUMBER);
 		entity.setNotes(form.getNotes());
 		Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
 		entity.setCreateDate(currentTimestamp);
@@ -133,7 +134,7 @@ public class CenterInfoService {
 		entity.setOperationalStatus(form.getOperationalStatus());
 		entity.setMaxStorageCapacity(form.getMaxStorageCapacity());
 		entity.setCurrentStorageCapacity(form.getCurrentStorageCapacity());
-		entity.setDeleteFlag(form.getDeleteFlagRegister());
+		entity.setDeleteFlag(NumberValidConsts.DELETE_FLAG_REGISTER_NUMBER);
 		entity.setNotes(form.getNotes());
 		Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
 		entity.setUpdateDate(currentTimestamp);
@@ -150,22 +151,22 @@ public class CenterInfoService {
 	 * @return
 	 */
 	@Transactional
-	public void deleteCenterInfoData(CenterInfoForm form) {
+	public void deleteCenterInfoData(Integer centerId) {
 
 		// インスタンス化
 		CenterInfo entity = new CenterInfo();
 
 		//データベースの在庫センター情報を取得
-		entity = repository.findByCenterId(form.getCenterId());
+		entity = repository.findByCenterId(centerId);
 		
 		//在庫一覧とリンクしているセンター名があるか確認
-		if(repository.count(form.getCenterId()) > 0) {
+		if(repository.count(centerId) > 0) {
 			//在庫一覧とリンクしているセンター名がある場合、エラーを発生させて処理を中断する
 			throw new Error();
 		}
 
 		//各データを格納する
-		entity.setDeleteFlag(form.getDeleteFlagDeleter());
+		entity.setDeleteFlag(NumberValidConsts.DELETE_FLAG_DELETE_NUMBER);
 		Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
 		entity.setUpdateDate(currentTimestamp);
 

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -15,7 +15,7 @@ centerName.length.wrongInput=センター名は20文字以内で入力してく�
 centerInfo.data.fieldEmpty=※必須項目は全て入力してください。
 centerInfo.data.maxStorageCapacity.wrongInput=※最大容量は数字で入力してください。
 centerInfo.data.currentStorageCapacity.wrongInput=※現在容量は数字で入力してください。
-centerInfo.data.overStorageCapacity.wrongInput=※現在容量は最大容量を上回る容量を登録できません。
+centerInfo.data.StorageCapacityOver=※現在容量は最大容量を上回る容量を登録できません。
 centerInfo.data.format.wrongInput=半角数字で正しく入力してください。(ハイフン必須)
 centerInfo.data.number.wrongInput=半角数字で正しく入力してください。
 
@@ -27,6 +27,11 @@ address.length.wrongInput=住所は26文字以内で入力してください。
 #在庫センター更新画面
 centerInfoUpdate.transactionError=※更新時に予期せぬエラーが発生し異常終了しました。
 centerInfoUpdate.success=※在庫センター情報の更新が完了しました。
+
+#在庫センター削除画面
+centerInfoDelete.transactionError=※削除時に予期せぬエラーが発生し異常終了しました。
+centerInfoDelete.success=※在庫センター情報の削除が完了しました。
+centerInfoDelete.linking=※対象の在庫センター情報は、在庫一覧情報に紐付けがあるため削除できません
 
 # Spring Security が拾う例外のエラーメッセージをカスタマイズ
 AbstractUserDetailsAuthenticationProvider.badCredentials=管理者IDとパスワードの組み合わせが間違っています。

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/delete.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/delete.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+
+<head>
+	<title>InvenTrack - 削除</title>
+</head>
+
+<body>
+	<div class="d-flex justify-content-center align-items-center vh-100 bg-light">
+		<div class="card shadow-lg" style="width: 50%; max-width: 800px">
+			<div class="bg-warning text-dark text-center py-3">
+				<strong style="font-size: 30px; font-weight: bold">このセンターを削除しますか？</strong>
+			</div>
+			<div class="card-header bg-danger text-white py-2">
+				<h6 class="mb-0">在庫センター情報削除確認</h6>
+			</div>
+			<div class="card-body py-2">
+				<!-- th:objectでcenterInfoをフォームにバインド -->
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+				<div class="card-body py-2">
+					<form class="small" th:action="@{/admin/centerInfo/delete}" method="post" th:object="${CenterInfoForm}">
+
+						<!-- PATCHリクエスト-->
+						<input type="hidden" name="_method" value="patch" />
+
+						<!-- 在庫センターId -->
+						<input type="hidden" class="form-control form-control-sm" id="deleteTerm" name="centerId" th:value="${centerInfoList.centerId}" />
+
+						<!-- 在庫センター名 -->
+						<div class="mb-2">
+							<label for="centerName" class="form-label">在庫センター名</label>
+							<input type="text" class="form-control form-control-sm" id="deleteTerm" name="centerName" th:value="${centerInfoList.centerName}" readonly />
+						</div>
+						<!-- 郵便番号 -->
+						<div class="mb-2">
+							<label for="postCode" class="form-label">郵便番号</label>
+							<input type="text" class="form-control form-control-sm" id="deleteTerm" name="postCode" th:value="${centerInfoList.postCode}" readonly />
+						</div>
+
+						<!-- 住所 -->
+						<div class="mb-2">
+							<label for="address" class="form-label">住所</label>
+							<input type="text" class="form-control form-control-sm" id="deleteTerm" name="address" th:value="${centerInfoList.address}" readonly />
+						</div>
+
+						<!-- 電話番号 -->
+						<div class="mb-2">
+							<label for="phoneNumber" class="form-label">電話番号</label>
+							<input type="text" class="form-control form-control-sm" id="deleteTerm" name="phoneNumber" th:value="${centerInfoList.phoneNumber}" readonly />
+						</div>
+
+						<!-- 管理者名 -->
+						<div class="mb-2">
+							<label for="managerName" class="form-label">管理者名</label>
+							<input type="text" class="form-control form-control-sm" id="deleteTerm" name="managerName" th:value="${centerInfoList.managerName}" readonly />
+						</div>
+
+						<!-- 稼働状況ステータス -->
+						<div class="mb-2">
+							<label class="form-label">稼働状況ステータス</label>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="0" id="deleteTerm" name="operationalStatus" th:field="${centerInfoList.operationalStatus}" disabled />
+								<label class="form-check-label" for="operationalStatusActive">稼働中</label>
+							</div>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="1" id="deleteTerm" name="operationalStatus" th:field="${centerInfoList.operationalStatus}" disabled />
+								<label class="form-check-label" for="operationalStatusInactive">稼働停止</label>
+							</div>
+						</div>
+
+						<!-- 最大保管容量 -->
+						<div class="mb-2">
+							<label for="maxStorageCapacity" class="form-label">最大保管容量（m³）</label>
+							<input type="number" class="form-control form-control-sm" id="deleteTerm" name="maxStorageCapacity" th:value="${centerInfoList.maxStorageCapacity}" readonly />
+						</div>
+
+						<!-- 現在保管容量 -->
+						<div class="mb-2">
+							<label for="currentStorageCapacity" class="form-label">現在保管容量（m³）</label>
+							<input type="number" class="form-control form-control-sm" id="deleteTerm" name="currentStorageCapacity" th:value="${centerInfoList.currentStorageCapacity}" readonly />
+						</div>
+
+						<!-- 備考 -->
+						<div class="mb-2">
+							<label for="notes" class="form-label">備考</label>
+							<textarea class="form-control form-control-sm" id="deleteTerm" name="notes" th:text="${centerInfoList.notes}" rows="2"></textarea>
+						</div>
+
+						<!-- ボタン -->
+						<div class="d-flex justify-content-between">
+							<a href="/admin/centerInfo" class="btn btn-secondary btn-sm">キャンセル</a>
+							<button type="submit" class="btn btn-danger btn-sm"> 削除する </button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
@@ -87,6 +87,7 @@
 					<!-- ボタン -->
 					<div class="d-flex justify-content-between">
 						<a href="/admin/centerInfo" class="btn btn-secondary btn-sm">キャンセル</a>
+						<a th:href="@{/admin/centerInfo/delete/{id}(id=${centerInfoList.centerId})}" class="btn btn-secondary btn-sm">削除する</a>
 						<button type="submit" class="btn btn-success btn-sm">更新する</button>
 					</div>
 				</form>


### PR DESCRIPTION
## 概要

削除画面の実装、およびセンター情報の論理削除機能の実装

## 実装方針・詳細

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 実装方針・詳細 1
・更新・削除画面
削除ボタンの実装。

- 実装方針・詳細 2
・削除画面
削除ボタンを押下するとセンター情報の論理削除を実行する。
削除時に、在庫一覧情報にて削除対象のセンター情報が登録されている場合、削除しないようにする

## 影響範囲
・更新・削除画面
